### PR TITLE
Fixes for ole.CoInitialize behavior.

### DIFF
--- a/manage.go
+++ b/manage.go
@@ -31,16 +31,16 @@ func (t *TaskService) initialize() error {
 
 	schedClassID, err := ole.ClassIDFrom("Schedule.Service.1")
 	if err != nil {
-		defer ole.CoUninitialize()
+		ole.CoUninitialize()
 		return getTaskSchedulerError(err)
 	}
 	taskSchedulerObj, err := ole.CreateInstance(schedClassID, nil)
 	if err != nil {
-		defer ole.CoUninitialize()
+		ole.CoUninitialize()
 		return getTaskSchedulerError(err)
 	}
 	if taskSchedulerObj == nil {
-		defer ole.CoUninitialize()
+		ole.CoUninitialize()
 		return errors.New("Could not create ITaskService object")
 	}
 	defer taskSchedulerObj.Release()


### PR DESCRIPTION
Accept err=S_FALSE from ole.CoInitialize. Call ole.CoUninitialize if we return err for any subsequent reason.

Addresses #23 